### PR TITLE
Fix path to dev requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands=flake8 rentomatic
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/rentomatic
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements/dev.txt
 commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}


### PR DESCRIPTION
Thank you very much for the book!
I started the walkthrough and noticed that path to requirements file in ``tox.ini`` is incorrect.

In fact, there are other changes to be made, as far as I understand: remove py33, py34, py35, py36 as there are no dataclasses (not sure about pypy).
