### PR TITLE
fix: sqlalchemy warning

### DIFF
--- a/rentomatic/repository/postgres_objects.py
+++ b/rentomatic/repository/postgres_objects.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, Float
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 


### PR DESCRIPTION
Integration test results has an warning message according to SQLAlchemy on the tag `ed2-c06-s04`.
This is because of using deprecated module.

```
============================================================ warnings summary ============================================================
rentomatic/repository/postgres_objects.py:4
  /Users/dexter/src/rentomatic/rentomatic/repository/postgres_objects.py:4: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()
```